### PR TITLE
feat(api): add upload options and remove preview tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Add this minimal configuration to your MCP client (e.g., Claude Desktop):
 mcpServers:
   zipline:
     command: npx
-    args: ['zipline-mcp']
+    args: ['-y', 'zipline-mcp']
     environment:
       ZIPLINE_TOKEN: 'your-api-token-here'
+      ZIPLINE_ENDPOINT: 'http://localhost:3000'
 ```
 
 ```json
@@ -66,9 +67,10 @@ mcpServers:
   "mcpServers": {
     "zipline": {
       "command": "npx",
-      "args": ["zipline-mcp"],
+      "args": ["-y", "zipline-mcp"],
       "environment": {
-        "ZIPLINE_TOKEN": "your-api-token-here"
+        "ZIPLINE_TOKEN": "your-api-token-here",
+        "ZIPLINE_ENDPOINT": "http://localhost:3000"
       }
     }
   }
@@ -82,6 +84,7 @@ mcpServers:
 - `command`: The executable to run (typically "npx")
 - `args`: Array containing ["zipline-mcp"]
 - `environment.ZIPLINE_TOKEN`: Your Zipline API token
+- `environment.ZIPLINE_ENDPOINT`: The URL of your Zipline server (default is "http://localhost:3000")
 
 ##### Optional Settings
 
@@ -92,7 +95,6 @@ mcpServers:
 
 1. Store API tokens in environment variables, not in config files
 2. Use HTTPS for all connections to Zipline servers
-3. Restrict token permissions to only required scopes
 
 #### Troubleshooting Common Issues
 
@@ -100,7 +102,7 @@ mcpServers:
 
 - Symptom: "Invalid authorization token" errors
 - Solutions:
-  - Verify token validity and permissions
+  - Verify token validity
   - Check for typos in the ZIPLINE_TOKEN value
   - Ensure token is passed via environment variable
 
@@ -340,13 +342,6 @@ Uploads a file to the Zipline server and returns a detailed success message.
 #### `get_upload_url_only`
 
 Uploads a file and returns only the download URL.
-
-- `filePath`: Path to the file to upload. Supported extensions: txt, md, gpx, html, json, xml, csv, js, css, py, sh, yaml, yml, png, jpg, jpeg, gif, webp, svg, bmp, tiff, ico, heic, avif
-- `format` (optional): Filename format. Supported values: "random", "uuid", "date", "name", "gfycat" (alias for "random-words"), "random-words". Defaults to "random".
-
-#### `preview_upload_command`
-
-Generates and previews the curl command that will be used for uploading.
 
 - `filePath`: Path to the file to upload. Supported extensions: txt, md, gpx, html, json, xml, csv, js, css, py, sh, yaml, yml, png, jpg, jpeg, gif, webp, svg, bmp, tiff, ico, heic, avif
 - `format` (optional): Filename format. Supported values: "random", "uuid", "date", "name", "gfycat" (alias for "random-words"), "random-words". Defaults to "random".

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -12,10 +12,10 @@ export interface UploadOptions {
     mimeType: string;
     size: number;
   };
-  deletesAt?: string;
-  password?: string;
-  maxViews?: number;
-  folder?: string;
+  deletesAt?: string | undefined;
+  password?: string | undefined;
+  maxViews?: number | undefined;
+  folder?: string | undefined;
 }
 
 export interface ZiplineUploadResponse {
@@ -34,10 +34,21 @@ export interface ZiplineUploadResponse {
  * - Robust error handling for HTTP and network errors
  *
  * Enhanced Headers (all optional):
- * - deletesAt: File expiration time (e.g., "1d", "2h", "date=2025-12-31T23:59:59Z")
- * - password: Password protection for the uploaded file
- * - maxViews: Maximum number of views before file removal (≥ 0)
- * - folder: Target folder ID (alphanumeric, must exist)
+ * - deletesAt: File expiration time. Supports:
+ *   - Relative durations: "1d" (1 day), "2h" (2 hours), "30m" (30 minutes)
+ *   - Absolute dates: "date=YYYY-MM-DDTHH:mm:ssZ" (e.g., "date=2025-12-31T23:59:59Z")
+ *   - Validation ensures the value is either a valid duration or ISO-8601 date.
+ * - password: Protects the uploaded file with a password.
+ *   - Must be a non-empty string.
+ *   - Whitespace-only passwords are rejected.
+ *   - Passwords are never logged or exposed in error messages for security.
+ * - maxViews: Limits the number of times a file can be viewed before it becomes unavailable.
+ *   - Must be a non-negative integer (≥ 0).
+ *   - When the counter reaches 0, the file becomes inaccessible.
+ * - folder: Specifies the ID of the folder where the upload should be placed.
+ *   - Must be a non-empty alphanumeric string.
+ *   - Special characters and whitespace are rejected.
+ *   - If the specified folder doesn't exist, the upload will fail.
  */
 export async function uploadFile(opts: UploadOptions): Promise<string> {
   const {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,17 +101,6 @@ describe('Zipline MCP Server', () => {
     );
   });
 
-  it('should register the preview_upload_command tool', async () => {
-    const { server } = (await import('./index')) as unknown as {
-      server: MockServer;
-    };
-    expect(server.registerTool).toHaveBeenCalledWith(
-      'preview_upload_command',
-      expect.any(Object),
-      expect.any(Function)
-    );
-  });
-
   it('should register the validate_file tool', async () => {
     const { server } = (await import('./index')) as unknown as {
       server: MockServer;
@@ -250,55 +239,6 @@ describe('Zipline MCP Server', () => {
         {}
       );
       expect(!resultAlias.isError).toBe(true); // Should succeed since spawn is now mocked properly
-    });
-  });
-
-  describe('preview_upload_command tool', () => {
-    let server: MockServer;
-
-    beforeEach(async () => {
-      vi.resetModules();
-      Object.values(fsMock).forEach((fn) => fn.mockReset());
-      const imported = (await import('./index')) as unknown as {
-        server: MockServer;
-      };
-      server = imported.server;
-    });
-
-    const getToolHandler = (toolName: string): ToolHandler | undefined => {
-      const call = vi
-        .mocked(server.registerTool)
-        .mock.calls.find((c: unknown[]) => c[0] === toolName);
-      return call?.[2] as ToolHandler | undefined;
-    };
-
-    it('should generate preview command with normalized format', async () => {
-      const handler = getToolHandler('preview_upload_command');
-      if (!handler) throw new Error('Handler not found');
-
-      // Test with alias
-      const result1 = await handler(
-        { filePath: '/path/to/file.txt', format: 'gfycat' },
-        {}
-      );
-      expect(!result1.isError).toBe(true);
-      expect(result1.content[0]?.text).toContain("format: 'random-words'");
-
-      // Test with uppercase
-      const result2 = await handler(
-        { filePath: '/path/to/file.txt', format: 'UUID' },
-        {}
-      );
-      expect(!result2.isError).toBe(true);
-      expect(result2.content[0]?.text).toContain("format: 'uuid'");
-
-      // Test with invalid format
-      const result3 = await handler(
-        { filePath: '/path/to/file.txt', format: 'invalid' },
-        {}
-      );
-      expect(result3.isError).toBe(true);
-      expect(result3.content[0]?.text).toContain('Invalid format: invalid');
     });
   });
 });


### PR DESCRIPTION
- introduce new UploadOptions fields: deletesAt, password, maxViews, folder
- plumb new options through the upload flow in index.ts
- remove the preview_upload_command tool registration
- update tests to reflect removal and new options
- align README and typing to support enhanced upload configuration