### PR TITLE
fix(api): remove tool that was not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	npm install
 
 # Build the project
-build:
+build: clean
 	npm run build
 
 # Start the server

--- a/README.md
+++ b/README.md
@@ -337,14 +337,6 @@ This server provides the following tools:
 Uploads a file to the Zipline server and returns a detailed success message.
 
 - `filePath`: Path to the file to upload. Supported extensions: txt, md, gpx, html, json, xml, csv, js, css, py, sh, yaml, yml, png, jpg, jpeg, gif, webp, svg, bmp, tiff, ico, heic, avif
-- `format` (optional): Filename format. Supported values: "random", "uuid", "date", "name", "gfycat" (alias for "random-words"), "random-words". Defaults to "random".
-
-#### `get_upload_url_only`
-
-Uploads a file and returns only the download URL.
-
-- `filePath`: Path to the file to upload. Supported extensions: txt, md, gpx, html, json, xml, csv, js, css, py, sh, yaml, yml, png, jpg, jpeg, gif, webp, svg, bmp, tiff, ico, heic, avif
-- `format` (optional): Filename format. Supported values: "random", "uuid", "date", "name", "gfycat" (alias for "random-words"), "random-words". Defaults to "random".
 
 #### `validate_file`
 

--- a/src/httpClient.test.ts
+++ b/src/httpClient.test.ts
@@ -215,18 +215,18 @@ describe('httpClient.uploadFile (TDD - tests first)', () => {
 
 // Unit tests for header validation
 describe('Header Validation', () => {
-  describe('validateDeletesAt', () => {
+  describe('validateDeleteAt', () => {
     it('accepts valid relative duration strings', async () => {
-      const { validateDeletesAt } = await import('./httpClient');
+      const { validateDeleteAt } = await import('./httpClient');
 
-      expect(() => validateDeletesAt('1d')).not.toThrow();
-      expect(() => validateDeletesAt('2h')).not.toThrow();
-      expect(() => validateDeletesAt('30m')).not.toThrow();
-      expect(() => validateDeletesAt('7d')).not.toThrow();
+      expect(() => validateDeleteAt('1d')).not.toThrow();
+      expect(() => validateDeleteAt('2h')).not.toThrow();
+      expect(() => validateDeleteAt('30m')).not.toThrow();
+      expect(() => validateDeleteAt('7d')).not.toThrow();
     });
 
     it('accepts valid absolute date format with date= prefix', async () => {
-      const { validateDeletesAt } = await import('./httpClient');
+      const { validateDeleteAt } = await import('./httpClient');
 
       // Use dates that are definitely in the future
       const futureDate1 = new Date();
@@ -236,40 +236,40 @@ describe('Header Validation', () => {
       futureDate2.setFullYear(futureDate2.getFullYear() + 2);
 
       expect(() =>
-        validateDeletesAt(`date=${futureDate1.toISOString()}`)
+        validateDeleteAt(`date=${futureDate1.toISOString()}`)
       ).not.toThrow();
       expect(() =>
-        validateDeletesAt(`date=${futureDate2.toISOString()}`)
+        validateDeleteAt(`date=${futureDate2.toISOString()}`)
       ).not.toThrow();
     });
 
     it('rejects invalid relative duration strings', async () => {
-      const { validateDeletesAt } = await import('./httpClient');
+      const { validateDeleteAt } = await import('./httpClient');
 
-      expect(() => validateDeletesAt('')).toThrow();
-      expect(() => validateDeletesAt('1')).toThrow();
-      expect(() => validateDeletesAt('x')).toThrow();
-      expect(() => validateDeletesAt('1x')).toThrow();
-      expect(() => validateDeletesAt('-1d')).toThrow();
+      expect(() => validateDeleteAt('')).toThrow();
+      expect(() => validateDeleteAt('1')).toThrow();
+      expect(() => validateDeleteAt('x')).toThrow();
+      expect(() => validateDeleteAt('1x')).toThrow();
+      expect(() => validateDeleteAt('-1d')).toThrow();
     });
 
     it('rejects invalid absolute date format', async () => {
-      const { validateDeletesAt } = await import('./httpClient');
+      const { validateDeleteAt } = await import('./httpClient');
 
-      expect(() => validateDeletesAt('date=')).toThrow();
-      expect(() => validateDeletesAt('date=invalid')).toThrow();
-      expect(() => validateDeletesAt('date=2025-13-01T00:00:00Z')).toThrow();
-      expect(() => validateDeletesAt('2025-01-01T00:00:00Z')).toThrow(); // missing date= prefix
+      expect(() => validateDeleteAt('date=')).toThrow();
+      expect(() => validateDeleteAt('date=invalid')).toThrow();
+      expect(() => validateDeleteAt('date=2025-13-01T00:00:00Z')).toThrow();
+      expect(() => validateDeleteAt('2025-01-01T00:00:00Z')).toThrow(); // missing date= prefix
     });
 
     it('rejects past dates', async () => {
-      const { validateDeletesAt } = await import('./httpClient');
+      const { validateDeleteAt } = await import('./httpClient');
 
       // Use a date in the past
       const pastDate = new Date();
       pastDate.setDate(pastDate.getDate() - 1);
       expect(() =>
-        validateDeletesAt(`date=${pastDate.toISOString()}`)
+        validateDeleteAt(`date=${pastDate.toISOString()}`)
       ).toThrow();
     });
   });
@@ -509,7 +509,7 @@ describe('Header Validation', () => {
       expect(headers['x-zipline-format']).toBe(format);
     });
 
-    it('rejects upload with invalid deletes-at header before making request', async () => {
+    it('rejects upload with invalid delete-at header before making request', async () => {
       fsMock.readFile.mockResolvedValue(sampleContent);
 
       const { uploadFile } = await import('./httpClient');
@@ -522,7 +522,7 @@ describe('Header Validation', () => {
           format,
           deletesAt: 'invalid',
         })
-      ).rejects.toThrow('deletes-at header must be in format like');
+      ).rejects.toThrow('delete-at header must be in format like');
 
       // Ensure fetch was not called due to validation failure
       expect(fetchSpy).not.toHaveBeenCalled();

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -70,7 +70,7 @@ export async function uploadFile(opts: UploadOptions): Promise<string> {
   if (!format) throw new Error('format is required');
 
   // Validate optional headers if provided
-  if (deletesAt !== undefined) validateDeletesAt(deletesAt);
+  if (deletesAt !== undefined) validateDeleteAt(deletesAt);
   if (password !== undefined) validatePassword(password);
   if (maxViews !== undefined) validateMaxViews(maxViews);
   if (folder !== undefined) validateFolder(folder);
@@ -216,45 +216,45 @@ function extractFirstFileUrl(json: unknown): string | undefined {
 }
 
 // Header validation functions
-export function validateDeletesAt(deletesAt: string): void {
-  if (!deletesAt || typeof deletesAt !== 'string') {
-    throw new Error('deletes-at header must be a non-empty string');
+export function validateDeleteAt(deleteAt: string): void {
+  if (!deleteAt || typeof deleteAt !== 'string') {
+    throw new Error('delete-at header must be a non-empty string');
   }
 
   // Check if it's an absolute date format
-  if (deletesAt.startsWith('date=')) {
-    const dateStr = deletesAt.substring(5);
+  if (deleteAt.startsWith('date=')) {
+    const dateStr = deleteAt.substring(5);
     if (!dateStr) {
       throw new Error(
-        'deletes-at header with date= prefix must include a valid date'
+        'delete-at header with date= prefix must include a valid date'
       );
     }
 
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
-      throw new Error('deletes-at header contains invalid date format');
+      throw new Error('delete-at header contains invalid date format');
     }
 
     // Check if date is in the future
     const now = new Date();
     if (date <= now) {
-      throw new Error('deletes-at header must specify a future date');
+      throw new Error('delete-at header must specify a future date');
     }
   } else {
     // Parse as relative duration
     const durationRegex = /^(\d+)([dhm])$/;
-    const match = deletesAt.match(durationRegex);
+    const match = deleteAt.match(durationRegex);
 
     if (!match) {
       throw new Error(
-        'deletes-at header must be in format like "1d", "2h", "30m" or "date=2025-01-01T00:00:00Z"'
+        'delete-at header must be in format like "1d", "2h", "30m" or "date=2025-01-01T00:00:00Z"'
       );
     }
 
     const value = parseInt(match[1]!, 10);
 
     if (value <= 0) {
-      throw new Error('deletes-at header duration must be positive');
+      throw new Error('delete-at header duration must be positive');
     }
   }
 }


### PR DESCRIPTION
Migrate all delete-at header logic to the new deleteAt naming and align error messages across the codebase. Update tests, types, and input schema references to reflect the change, while preserving existing validation rules for relative durations and absolute future dates.