### PR TITLE
feat(httpClient): implement downloadExternalUrl

### DIFF
--- a/src/download.integration.test.ts
+++ b/src/download.integration.test.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-function-type */
+process.env.ZIPLINE_TOKEN = 'test-token';
+process.env.ZIPLINE_ENDPOINT = 'http://localhost:3000';
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock MCP server and transport like in index.test
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
+  const McpServer = vi.fn().mockImplementation(() => {
+    const registerToolMock = vi.fn();
+    registerToolMock.mockImplementation(() => {});
+    return {
+      registerTool: registerToolMock,
+      connect: vi.fn(),
+    };
+  });
+  return { McpServer };
+});
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+// Mock downloadExternalUrl implementation to simulate real behavior
+const httpClientMock = {
+  downloadExternalUrl: vi.fn(),
+};
+vi.mock('./httpClient', () => httpClientMock);
+
+// Minimal fs mock to avoid real disk ops
+const fsMock = {
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+  readFile: vi.fn(),
+  rm: vi.fn(),
+  readdir: vi.fn(),
+};
+vi.mock('fs/promises', () => ({ ...fsMock, default: fsMock }));
+
+describe('download_external_url tool (integration)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('registers the download_external_url tool and returns success content', async () => {
+    // Arrange: make downloader resolve to a path
+    httpClientMock.downloadExternalUrl.mockResolvedValue(
+      '/home/user/.zipline_tmp/users/hash/test.txt'
+    );
+
+    // Act: import index (which registers tools)
+    const imported = await import('./index');
+    const server = imported.server as unknown as any;
+
+    // Find the registered tool handler from mock.calls
+    const calls = server.registerTool?.mock?.calls ?? [];
+    const call = calls.find((c: unknown[]) => c[0] === 'download_external_url');
+    expect(call).toBeDefined();
+    type ToolHandler = (
+      args: Record<string, unknown>,
+      extra: Record<string, unknown>
+    ) => Promise<Record<string, unknown> | void>;
+    const handler = call?.[2] as unknown as ToolHandler;
+    expect(typeof handler).toBe('function');
+
+    // Call the handler
+    const raw = await handler({ url: 'https://example.com/file.txt' }, {});
+    const result = raw as unknown as {
+      content?: Array<{ type?: string; text?: string }>;
+      [k: string]: unknown;
+    };
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.content?.[0]?.text).toContain(
+      'Local path: /home/user/.zipline_tmp/users/hash/test.txt'
+    );
+    expect(httpClientMock.downloadExternalUrl).toHaveBeenCalledWith(
+      'https://example.com/file.txt',
+      {
+        timeout: 30000,
+      }
+    );
+  });
+
+  it('returns error response when downloader throws', async () => {
+    httpClientMock.downloadExternalUrl.mockRejectedValue(
+      new Error('Network failure')
+    );
+
+    const imported = await import('./index');
+    const server = imported.server as any;
+
+    const call = vi
+      .mocked(server.registerTool)
+      .mock.calls.find((c: unknown[]) => c[0] === 'download_external_url');
+    expect(call).toBeDefined();
+    const handler = call?.[2] as Function;
+    expect(handler).toBeDefined();
+
+    const result = await handler({ url: 'https://example.com/file.txt' }, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('DOWNLOAD FAILED');
+    expect(result.content?.[0]?.text).toContain('Network failure');
+  });
+});

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, @typescript-eslint/require-await, @typescript-eslint/no-unsafe-member-access */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Minimal fs mock for write/remove operations
+const fsMock = {
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+  rm: vi.fn(),
+};
+vi.mock('fs/promises', () => ({ ...fsMock, default: fsMock }));
+
+// Mock sandbox utilities used by the downloader so tests don't depend on real FS layout
+vi.mock('./sandboxUtils', () => ({
+  ensureUserSandbox: vi.fn(async () => '/home/user/.zipline_tmp/users/hash'),
+  resolveSandboxPath: vi.fn(
+    (filename: string) => `/home/user/.zipline_tmp/users/hash/${filename}`
+  ),
+  validateFilename: vi.fn(() => null),
+  logSandboxOperation: vi.fn(() => {}),
+}));
+
+describe('downloadExternalUrl (TDD)', () => {
+  const url = 'https://example.com/files/test.txt';
+  const filename = 'test.txt';
+  const fakeContent = new TextEncoder().encode('hello world');
+
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let OriginalAbortController: typeof AbortController;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    OriginalAbortController = globalThis.AbortController;
+
+    const g = globalThis as any;
+    fetchSpy = vi
+      .spyOn(g, 'fetch')
+      .mockImplementation(async (_input: any, _init?: any) => {
+        const res = {
+          ok: true,
+          status: 200,
+          arrayBuffer: async () => fakeContent.buffer,
+          headers: {
+            get: (k: string) =>
+              k.toLowerCase() === 'content-length'
+                ? String(fakeContent.length)
+                : null,
+          },
+          url: url,
+        };
+        return res as any;
+      });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    globalThis.AbortController = OriginalAbortController;
+  });
+
+  it('downloads a file and returns absolute path', async () => {
+    const { downloadExternalUrl } = await import('./httpClient');
+
+    const result = await downloadExternalUrl(url, { timeout: 10000 });
+
+    expect(result).toBe('/home/user/.zipline_tmp/users/hash/test.txt');
+    // writeFile is called with path and binary data
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      '/home/user/.zipline_tmp/users/hash/test.txt',
+      expect.any(Uint8Array)
+    );
+  });
+
+  it('rejects unsupported URL schemes', async () => {
+    const { downloadExternalUrl } = await import('./httpClient');
+    await expect(downloadExternalUrl('ftp://example.com/file')).rejects.toThrow(
+      /unsupported scheme|invalid url/i
+    );
+  });
+
+  it('throws on HTTP errors', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => 'Not Found',
+    } as any);
+
+    const { downloadExternalUrl } = await import('./httpClient');
+    await expect(downloadExternalUrl(url)).rejects.toThrow(
+      /HTTP 404|Not Found/i
+    );
+  });
+
+  it('aborts on timeout', async () => {
+    let abortUnderlying: (() => void) | undefined;
+
+    class MockAbortController {
+      signal: AbortSignal;
+      constructor() {
+        const ac = new OriginalAbortController();
+        this.signal = ac.signal;
+        abortUnderlying = () => ac.abort();
+      }
+      abort() {
+        abortUnderlying?.();
+      }
+    }
+
+    globalThis.AbortController =
+      MockAbortController as unknown as typeof AbortController;
+
+    fetchSpy.mockImplementation(async (_input: any, init?: any) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new Error('The operation was aborted.'));
+        });
+      }) as any;
+    });
+
+    const { downloadExternalUrl } = await import('./httpClient');
+    await expect(downloadExternalUrl(url, { timeout: 5 })).rejects.toThrow(
+      /abort|timeout/i
+    );
+  });
+
+  it('rejects files larger than 100MB', async () => {
+    const bigSize = 101 * 1024 * 1024;
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(1),
+      headers: {
+        get: (k: string) =>
+          k.toLowerCase() === 'content-length' ? String(bigSize) : null,
+      },
+      url,
+    } as any);
+
+    const { downloadExternalUrl } = await import('./httpClient');
+    await expect(downloadExternalUrl(url)).rejects.toThrow(
+      /exceed|too large|100MB/i
+    );
+  });
+
+  it('removes partial file on failure', async () => {
+    // Simulate fetch that throws mid-download
+    fetchSpy.mockImplementationOnce(async () => {
+      throw new Error('Network failure');
+    });
+
+    const { downloadExternalUrl } = await import('./httpClient');
+    await expect(downloadExternalUrl(url)).rejects.toThrow(/Network failure/i);
+
+    // Ensure cleanup attempted
+    expect(fsMock.rm).toHaveBeenCalledWith(
+      '/home/user/.zipline_tmp/users/hash/test.txt',
+      { force: true }
+    );
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,6 +31,9 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
 // Mock the httpClient module
 vi.mock('./httpClient', () => ({
   uploadFile: vi.fn().mockResolvedValue('https://example.com/file.txt'),
+  downloadExternalUrl: vi
+    .fn()
+    .mockResolvedValue('/home/user/.zipline_tmp/users/hash/downloaded.txt'),
 }));
 
 const fsMock = {


### PR DESCRIPTION
Add a new downloadExternalUrl function that downloads a remote HTTP(S) URL into the user sandbox with timeout, size limits, and safe file handling. It validates the URL scheme, enforces a max file size, writes to sandbox storage, and cleans up partial files on failure. Exposes specific error types and logs operations for observability. Also wires up the new download_external_url tool registration and associated tests.