### PR TITLE
feat(http): add support for originalName header

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ This server provides the following tools:
 Uploads a file to the Zipline server and returns a detailed success message.
 
 - `filePath`: Path to the file to upload. Supported extensions: txt, md, gpx, html, json, xml, csv, js, css, py, sh, yaml, yml, png, jpg, jpeg, gif, webp, svg, bmp, tiff, ico, heic, avif
+- `originalName`: (optional) Original filename to preserve during download. This parameter is sent as the `x-zipline-original-name` header to the Zipline server. The original filename will be used when downloading the file, not when storing it. Must be a non-empty string without path separators.
 
 #### `validate_file`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,10 @@ const uploadFileInputSchema = {
     .string()
     .optional()
     .describe('Target folder ID (alphanumeric, must exist)'),
+  originalName: z
+    .string()
+    .optional()
+    .describe('Original filename to preserve during download'),
 };
 
 server.registerTool(
@@ -193,6 +197,7 @@ server.registerTool(
     password = undefined,
     maxViews = undefined,
     folder = undefined,
+    originalName = undefined,
   }: {
     filePath: string;
     format?: FormatType | undefined;
@@ -200,6 +205,7 @@ server.registerTool(
     password?: string | undefined;
     maxViews?: number | undefined;
     folder?: string | undefined;
+    originalName?: string | undefined;
   }) => {
     try {
       // Validate and normalize format
@@ -234,6 +240,7 @@ server.registerTool(
         maxViews,
         folder,
         deletesAt,
+        originalName,
       };
 
       const url = await uploadFile(uploadOptions);


### PR DESCRIPTION
- introduce originalName option in UploadOptions
- validateOriginalName (non-empty, string, no path separators)
- send x-zipline-original-name header when provided
- add tests for header inclusion and invalid values
- update type definitions and server/tool integration to accept originalName